### PR TITLE
Se conectó catalog.yml a penal_df en gdrive

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -48,3 +48,9 @@ example_iris_data:
   filepath: data/01_raw/iris.csv
 
 
+d1_data:
+  type: api.APIDataSet
+  url: https://sheets.googleapis.com/v4/spreadsheets/1cH5NqQAVbh5nzBf7OWNmGcZfwYzXcZq8kLon6Oje3nQ/values/penal_df
+  params:
+    key: AIzaSyCX_Pho8CI8-QZRonJCA49k80tDCH_fTB8
+


### PR DESCRIPTION
Se puede acceder al data set del desafío 1 utilizando `context.catalog.load("d1_data")`. Esto retorna un objeto de tipo **Response,** al cual es necesario "parsearlo" con `.json()['values']`.

Resumiendo los pasos:

`data = context.catalog.load("d1_data").json()['values']`
`df = pd.DataFrame(data)`